### PR TITLE
More links on public authority pages

### DIFF
--- a/lib/views/public_body/_more_info.html.erb
+++ b/lib/views/public_body/_more_info.html.erb
@@ -48,6 +48,13 @@
   <% end %>
 <% end %>
 
+<% if public_body.has_tag?('ofs') %>
+  <% public_body.get_tag_values('ofs').each do |tag_value| %>
+      <%= link_to _('Provider register'),
+                    "https://www.officeforstudents.org.uk/advice-and-guidance/the-register/the-ofs-register/#/provider/#{ tag_value }" %><br>
+  <% end %>
+<% end %>
+
 <% if public_body.has_tag?('matuid') %>
   <% public_body.get_tag_values('matuid').each do |tag_value| %>
       <%= link_to _('Establishment group information'),
@@ -59,6 +66,20 @@
   <% public_body.get_tag_values('spuid').each do |tag_value| %>
       <%= link_to _('Establishment group information (sponsor)'),
                     "https://get-information-schools.service.gov.uk/Groups/Group/Details/#{ tag_value }" %><br>
+  <% end %>
+<% end %>
+
+<% if public_body.has_tag?('lei') %>
+  <% public_body.get_tag_values('lei').each do |tag_value| %>
+      <%= link_to _('Legal Entity Identifier'),
+                    "http://openleis.com/legal_entities/#{ tag_value }" %><br>
+  <% end %>
+<% end %>
+
+<% if public_body.has_tag?('wikidata') %>
+  <% public_body.get_tag_values('wikidata').each do |tag_value| %>
+      <%= link_to _('Wikidata page'),
+                    "https://www.wikidata.org/wiki/#{ tag_value }" %><br>
   <% end %>
 <% end %>
 


### PR DESCRIPTION
## Relevant issue(s)
There are more links we can add on public authority pages.

## What does this do?
Adds links for:
- Office for Students (regulator) pages.
- Legal Entity Identifiers (LEI) codes.
- WikiData.

## Why was this needed?
See above. Not needed just useful.

## Implementation notes
N/A.

## Screenshots
N/A.

## Notes to reviewer
This combines a number of changes into one commit. I had a few false starts getting to here.